### PR TITLE
Changing api endpoint to new url

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://www.fio.cz/"
+	defaultBaseURL = "https://fioapi.fio.cz/"
 	dateFormat     = "2006-01-02"
 )
 

--- a/transactions.go
+++ b/transactions.go
@@ -70,7 +70,7 @@ type TransactionsService struct {
 
 // ByPeriod returns transactions in date period.
 func (s *TransactionsService) ByPeriod(ctx context.Context, opts ByPeriodOptions) (*TransactionsResponse, error) {
-	urlStr := s.client.buildURL("ib_api/rest/periods", fmtDate(opts.DateFrom), fmtDate(opts.DateTo), "transactions.xml")
+	urlStr := s.client.buildURL("v1/rest/periods", fmtDate(opts.DateFrom), fmtDate(opts.DateTo), "transactions.xml")
 	req, err := s.client.newGetRequest(ctx, urlStr)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ type ExportOptions struct {
 // Export writes transactions in date period to provided writer.
 func (s *TransactionsService) Export(ctx context.Context, opts ExportOptions, w io.Writer) error {
 	exportFmt := fmt.Sprintf("transactions.%v", opts.Format)
-	urlStr := s.client.buildURL("ib_api/rest/periods", fmtDate(opts.DateFrom), fmtDate(opts.DateTo), exportFmt)
+	urlStr := s.client.buildURL("v1/rest/periods", fmtDate(opts.DateFrom), fmtDate(opts.DateTo), exportFmt)
 	req, err := s.client.newGetRequest(ctx, urlStr)
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ type GetStatementOptions struct {
 
 // GetStatement returns statement by its year/id.
 func (s *TransactionsService) GetStatement(ctx context.Context, opts GetStatementOptions) (*TransactionsResponse, error) {
-	urlStr := s.client.buildURL("ib_api/rest/by-id", strconv.Itoa(opts.Year), strconv.Itoa(opts.ID), "transactions.xml")
+	urlStr := s.client.buildURL("v1/rest/by-id", strconv.Itoa(opts.Year), strconv.Itoa(opts.ID), "transactions.xml")
 	req, err := s.client.newGetRequest(ctx, urlStr)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ type ExportStatementOptions struct {
 // ExportStatement writes statement by its year/id to provided writer.
 func (s *TransactionsService) ExportStatement(ctx context.Context, opts ExportStatementOptions, w io.Writer) error {
 	exportFmt := fmt.Sprintf("transactions.%v", opts.Format)
-	urlStr := s.client.buildURL("ib_api/rest/by-id", strconv.Itoa(opts.Year), strconv.Itoa(opts.ID), exportFmt)
+	urlStr := s.client.buildURL("v1/rest/by-id", strconv.Itoa(opts.Year), strconv.Itoa(opts.ID), exportFmt)
 	req, err := s.client.newGetRequest(ctx, urlStr)
 	if err != nil {
 		return err
@@ -183,7 +183,7 @@ type SetLastDownloadIDOptions struct {
 
 // SetLastDownloadID sets the last downloaded id of statement.
 func (s *TransactionsService) SetLastDownloadID(ctx context.Context, opts SetLastDownloadIDOptions) error {
-	urlStr := s.client.buildURL("ib_api/rest/set-last-id", strconv.Itoa(opts.ID), "")
+	urlStr := s.client.buildURL("v1/rest/set-last-id", strconv.Itoa(opts.ID), "")
 	req, err := s.client.newGetRequest(ctx, urlStr)
 	if err != nil {
 		return err
@@ -203,7 +203,7 @@ type SetLastDownloadDateOptions struct {
 
 // SetLastDownloadDate sets the last download date of statement.
 func (s *TransactionsService) SetLastDownloadDate(ctx context.Context, opts SetLastDownloadDateOptions) error {
-	urlStr := s.client.buildURL("ib_api/rest/set-last-date", fmtDate(opts.Date), "")
+	urlStr := s.client.buildURL("v1/rest/set-last-date", fmtDate(opts.Date), "")
 	req, err := s.client.newGetRequest(ctx, urlStr)
 	if err != nil {
 		return err

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -60,7 +60,7 @@ func TestByPeriod(t *testing.T) {
 
 	dateFrom := time.Now()
 	dateTo := time.Now()
-	urlStr := fmt.Sprintf("/ib_api/rest/periods/%v/%v/%v/transactions.xml", testingToken, fmtDate(dateFrom), fmtDate(dateTo))
+	urlStr := fmt.Sprintf("/v1/rest/periods/%v/%v/%v/transactions.xml", testingToken, fmtDate(dateFrom), fmtDate(dateTo))
 
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
@@ -129,7 +129,7 @@ func TestExport(t *testing.T) {
 	testingFormat := JSONFormat
 	dateFrom := time.Now()
 	dateTo := time.Now()
-	urlStr := fmt.Sprintf("/ib_api/rest/periods/%v/%v/%v/transactions.%v", testingToken, fmtDate(dateFrom), fmtDate(dateTo), testingFormat)
+	urlStr := fmt.Sprintf("/v1/rest/periods/%v/%v/%v/transactions.%v", testingToken, fmtDate(dateFrom), fmtDate(dateTo), testingFormat)
 
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
@@ -154,7 +154,7 @@ func TestGetStatement(t *testing.T) {
 
 	year := 2017
 	id := 1
-	urlStr := fmt.Sprintf("/ib_api/rest/by-id/%v/%v/%v/transactions.xml", testingToken, year, id)
+	urlStr := fmt.Sprintf("/v1/rest/by-id/%v/%v/%v/transactions.xml", testingToken, year, id)
 
 	mux.HandleFunc(urlStr, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)


### PR DESCRIPTION
Hello, fio is changing their api endpoint. There is no hurry. Old endpoint will be gone in 6 months.

Screenshot is from [fio api site](https://www.fio.cz/bank-services/internetbanking-api)



![Screenshot](https://github.com/jbub/fio/assets/17685266/5ad52a8a-a57c-4203-90ef-e00e9b85832f)
